### PR TITLE
 Fix incorrect base offset in 5D mean reduction (case 5, last_dim == 0)

### DIFF
--- a/xa_nnlib/algo/kernels/basic/xa_nn_mean_f32.c
+++ b/xa_nnlib/algo/kernels/basic/xa_nn_mean_f32.c
@@ -796,7 +796,9 @@ WORD32 xa_nn_mean_f32_f32(FLOAT32 *__restrict__ p_out,
                 WORD32 d4 = 0, d0d2, d1, d3;
                 for(d0d2 = 0; d0d2 < (Dim0 * Dim2); d0d2++)
                 {
-                    WORD32 base_offset = (d0d2 * Dim3 * Dim4);
+                    WORD32 d0 = d0d2 / Dim2;
+                    WORD32 d2 = d0d2 % Dim2;
+                    WORD32 base_offset = (d0 * Dim1 * Dim2 + d2) * Dim3 * Dim4;
                     sum = PDX_ZERO_MXF32();
                     for (d4 = 0; d4 < (Dim4 - CONST_THREE) ; d4 += CONST_FOUR)
                     {


### PR DESCRIPTION
 - In `xa_nn_mean_f32.c` case 5 (last_dim == 0), the fused `d0d2` loop computed `base_offset = d0d2 * Dim3 *   
  Dim4`, which is missing the `Dim1` factor on the d0 stride                                                    
  - This caused reads from wrong input positions when `Dim0 > 1` and `Dim1 > 1`, producing incorrect mean values
   for 5D tensors with non-contiguous reduce axes (e.g., reducing dims {1, 3})                                  
  - Fix decomposes `d0d2` back into `d0` and `d2` and computes the correct offset: `(d0 * Dim1 * Dim2 + d2) * Dim3 * Dim4`                                                                                                  
                                                            
  ## Reproducer                                                                                                 
  Input: 5D float32, shape [2, 2, 2, 2, 2], values 0..31    
  Op: mean(dim=[1, 3])                                                                                          
  Expected output[1,0,0] = 21.0                             
  Actual output[1,0,0] = 13.0 (wrong)