### PR TITLE
Fix off-by-one in broadcast mul remainder causing OOB writes

### DIFF
--- a/xa_nnlib/algo/kernels/basic/xa_nn_elm_mul_f32.c
+++ b/xa_nnlib/algo/kernels/basic/xa_nn_elm_mul_f32.c
@@ -381,7 +381,7 @@ static inline void internal_elm_mul_broadcast_1D_scalar_f32xf32_f32(
             z0 = PDX_MUL_MXF32(x0, y0);
             PDX_SA_MXF32_IP(z0, az, p_z);
         }
-        num_elm = num_elm - (n - CONST_ONE) * LOOP_UNROLL_BY_8;
+        num_elm = num_elm - n * LOOP_UNROLL_BY_8;
         if(num_elm >> LOG2_PDX_M)
         {
             PDX_LA_MXF32_IP(x0, ax, p_x);


### PR DESCRIPTION
## Summary                                                                                                    
  - In `internal_elm_mul_broadcast_1D_scalar_f32xf32_f32`, the remainder after the x8-unrolled loop was computed
   as `num_elm - (n - 1) * 8` instead of `num_elm - n * 8`                                                      
  - This inflated the remainder by 8 elements, causing an unconditional extra 4-element SIMD store past the     
  valid output region (16-byte heap buffer overflow)                                                            
  - Triggers when the output last dimension is not a multiple of 32 and `num_elm % 8 < 4` (e.g., `num_elm = 8, 16, 24`)                                                                                                      
                                                            
  ## Reproducer                                                                                                 
  a: shape=[2, 1], dtype=float32                            
  b: shape=[1, 8], dtype=float32                                                                                
  out: shape=[2, 8]                                         
                                                                                                                
  Loop processes 8 elements (all valid).                                                                        
  Remainder = 8 - (1-1)*8 = 8 (should be 0).                                                                    
  Result: 4 extra float32 OOB writes (16 bytes).